### PR TITLE
Repo: Update unless statement

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -74,7 +74,7 @@ define packagecloud::repo(
           exec { "apt_key_add_${normalized_name}":
             command => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
             path    => '/usr/bin/:/bin/',
-            unless  => "apt-key list | grep ${base_url}/${repo_name}",
+            unless  => "apt-key list | grep ${server_address}/${repo_name}",
             require => File[$normalized_name],
           }
 


### PR DESCRIPTION
If base_url is used, it may be manipulated by build_base_url to have a key as a username, which will not show up in the output of apt-key.

Example:
`wget --auth-no-challenge -qO - https://429757qy387g7q8goyoi4ghugwt:@packagecloud.io/sohonet/apt/gpgkey | apt-key add -`