### PR TITLE
Enable use of http proxy for requests to packagecloud servers

### DIFF
--- a/lib/puppet/parser/functions/get_read_token.rb
+++ b/lib/puppet/parser/functions/get_read_token.rb
@@ -94,7 +94,7 @@ module Packagecloud
     end
 
     def http(scheme, host, port, request)
-      if @proxy_host.nil?
+      if @proxy_host.nil? or @proxy_host.empty?
         http = Net::HTTP.new(host, port)
       else
         http = Net::HTTP.new(host, port, @proxy_host, @proxy_port)

--- a/lib/puppet/parser/functions/get_read_token.rb
+++ b/lib/puppet/parser/functions/get_read_token.rb
@@ -26,13 +26,15 @@ module Packagecloud
   class API
     attr_reader :name
 
-    def initialize(name, master_token, server_address, os, dist, hostname)
+    def initialize(name, master_token, server_address, os, dist, hostname, proxy_host, proxy_port)
       @name         = name
       @master_token = master_token
       @os           = os
       @dist         = dist
       @hostname     = hostname
       @base_url     = "https://packagecloud.io/install/repositories/"
+      @proxy_host   = proxy_host
+      @proxy_port   = proxy_port
 
       if !server_address.nil?
         @base_url = URI.join(server_address, "/install/repositories/").to_s
@@ -92,7 +94,12 @@ module Packagecloud
     end
 
     def http(scheme, host, port, request)
-      http = Net::HTTP.new(host, port)
+      if @proxy_host.nil?
+        http = Net::HTTP.new(host, port)
+      else
+        http = Net::HTTP.new(host, port, @proxy_host, @proxy_port)
+      end
+
       if scheme == "https"
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         http.use_ssl = true
@@ -116,11 +123,13 @@ module Puppet::Parser::Functions
     repo = args[0]
     master_token = args[1]
     server_address = args[2]
+    proxy_host = args[3]
+    proxy_port = args[4]
 
     os = lookupvar('::operatingsystem').downcase
     dist = lookupvar('::operatingsystemrelease')
     hostname = lookupvar('::fqdn')
 
-    Packagecloud::API.new(repo, master_token, server_address, os, dist, hostname).read_token
+    Packagecloud::API.new(repo, master_token, server_address, os, dist, hostname, proxy_host, proxy_port).read_token
   end
 end

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -26,9 +26,13 @@ define packagecloud::repo(
   $metadata_expire = 300,
   $server_address = 'https://packagecloud.io',
   $always_update_cache = true,
+  $proxy_host = undef,
+  $proxy_port = undef,
 ) {
   validate_string($type)
   validate_string($master_token)
+  validate_string($proxy_host)
+  validate_string($proxy_port)
 
   include ::packagecloud
 
@@ -41,11 +45,21 @@ define packagecloud::repo(
   $normalized_name = regsubst($repo_name, '\/', '_')
 
   if $master_token != undef {
-    $read_token = get_read_token($repo_name, $master_token, $server_address)
+    $read_token = get_read_token($repo_name, $master_token, $server_address, $proxy_host, $proxy_port)
     $base_url = build_base_url($read_token, $server_address)
   } else {
     $read_token = false
     $base_url = $server_address
+  }
+
+  if $proxy_host  {
+    if $proxy_port {
+      $proxy_env = ["https_proxy=https://${proxy_host}:${proxy_port}", "http_proxy=http://${proxy_host}:${proxy_port}"]
+    } else {
+      $proxy_env = ["https_proxy=https://${proxy_host}", "http_proxy=http://${proxy_host}"]
+    }
+  } else {
+    $proxy_env = []
   }
 
   case $type {
@@ -72,10 +86,11 @@ define packagecloud::repo(
           }
 
           exec { "apt_key_add_${normalized_name}":
-            command => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
-            path    => '/usr/bin/:/bin/',
-            unless  => "apt-key list | grep ${server_address}/${repo_name}",
-            require => File[$normalized_name],
+            command     => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
+            path        => '/usr/bin/:/bin/',
+            unless      => "apt-key list | grep ${server_address}/${repo_name}",
+            require     => File[$normalized_name],
+            environment => $proxy_env,
           }
 
           exec { "apt_get_update_${normalized_name}":

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -52,8 +52,8 @@ define packagecloud::repo(
     $base_url = $server_address
   }
 
-  if $proxy_host  {
-    if $proxy_port {
+  if $proxy_host != undef {
+    if $proxy_port != undef {
       $proxy_env = ["https_proxy=https://${proxy_host}:${proxy_port}", "http_proxy=http://${proxy_host}:${proxy_port}"]
     } else {
       $proxy_env = ["https_proxy=https://${proxy_host}", "http_proxy=http://${proxy_host}"]

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -55,8 +55,8 @@ describe 'packagecloud::repo' do
        "mode"=>"0644",})
     end
     it do
-      is_expected.to contain_file('username_publicrepo').with_content(/deb https:\/\/packagecloud.io\/username\/publicrepo\/debian  main/)
-      is_expected.to contain_file('username_publicrepo').with_content(/deb-src https:\/\/packagecloud.io\/username\/publicrepo\/debian  main/)
+      is_expected.to contain_file('username_publicrepo').with_content(/deb https:\/\/packagecloud.io\/username\/publicrepo\/debian jesse main/)
+      is_expected.to contain_file('username_publicrepo').with_content(/deb-src https:\/\/packagecloud.io\/username\/publicrepo\/debian jesse main/)
     end
     it do
       is_expected.to contain_exec('apt_get_update_username_publicrepo').
@@ -90,6 +90,7 @@ describe 'packagecloud::repo' do
         :osreleasemaj              => '7',
         :operatingsystem           => 'CentOS',
         :architecture              => 'x86_64',
+        :pygpgme_installed         => 'true'
       }}
 
 
@@ -122,6 +123,7 @@ describe 'packagecloud::repo' do
         :osreleasemaj              => '7',
         :operatingsystem           => 'CentOS',
         :architecture              => 'x86_64',
+        :pygpgme_installed         => 'true'
       }}
 
 
@@ -152,6 +154,7 @@ describe 'packagecloud::repo' do
         :osreleasemaj              => '8',
         :operatingsystem           => 'Debian',
         :architecture              => 'x86_64',
+        :lsbdistcodename           => 'jesse'
       }}
 
       let(:title) { 'username/publicrepo' }
@@ -180,6 +183,7 @@ describe 'packagecloud::repo' do
         :osreleasemaj              => '8',
         :operatingsystem           => 'Debian',
         :architecture              => 'x86_64',
+        :lsbdistcodename           => 'jesse'
       }}
 
       let(:title) { 'username/publicrepo' }
@@ -200,6 +204,69 @@ describe 'packagecloud::repo' do
       it do
         is_expected.to contain_exec('apt_get_update_username_publicrepo').
                with_refreshonly(true)
+      end
+    end
+
+    context 'with proxy host and port' do
+      let(:facts) {{
+        :osfamily                  => 'Debian',
+        :osreleasemaj              => '8',
+        :operatingsystem           => 'Debian',
+        :architecture              => 'x86_64',
+        :lsbdistcodename           => 'jesse'
+      }}
+
+      let(:title) { 'username/publicrepo' }
+
+      let(:params) do
+        {
+          :type       => 'deb',
+          :proxy_host => 'proxy.example.com',
+          :proxy_port => '8080'
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('apt_key_add_username_publicrepo').
+          with(
+            {
+              "command" => 'wget --auth-no-challenge -qO - https://packagecloud.io/username/publicrepo/gpgkey | apt-key add -',
+              "path"    => "/usr/bin/:/bin/",
+              "require" => "File[username_publicrepo]",
+              "environment" => ["https_proxy=https://proxy.example.com:8080", "http_proxy=http://proxy.example.com:8080"]
+            }
+        )
+      end
+    end
+
+    context 'with proxy host' do
+      let(:facts) {{
+        :osfamily                  => 'Debian',
+        :osreleasemaj              => '8',
+        :operatingsystem           => 'Debian',
+        :architecture              => 'x86_64',
+        :lsbdistcodename           => 'jesse'
+      }}
+
+      let(:title) { 'username/publicrepo' }
+
+      let(:params) do
+        {
+          :type       => 'deb',
+          :proxy_host => 'proxy.example.com',
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('apt_key_add_username_publicrepo').
+          with(
+            {
+              "command" => 'wget --auth-no-challenge -qO - https://packagecloud.io/username/publicrepo/gpgkey | apt-key add -',
+              "path"    => "/usr/bin/:/bin/",
+              "require" => "File[username_publicrepo]",
+              "environment" => ["https_proxy=https://proxy.example.com", "http_proxy=http://proxy.example.com"]
+            }
+        )
       end
     end
   end

--- a/spec/functions/get_read_token_spec.rb
+++ b/spec/functions/get_read_token_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'net/http'
+require 'puppet/parser/functions/get_read_token'
+
+
+describe 'get_read_token' do
+  before do
+    allow(scope).to receive(:lookupvar).with('::operatingsystem') { 'ubuntu' }
+    allow(scope).to receive(:lookupvar).with('::operatingsystemrelease') { '20.04' }
+    allow(scope).to receive(:lookupvar).with('::fqdn') { 'test-host' }
+  end
+
+  context 'no proxy http' do
+    it do
+      response = Net::HTTPSuccess.new(1.0, '200', 'OK')
+      http = instance_double(Net::HTTP) 
+      allow(Net::HTTP).to receive(:new).with('packagecloud.io', 80) { http }
+      expect(http).to receive(:start) { response }
+      expect(response).to receive(:body) { 'read-token' }
+
+      is_expected.to run.with_params('test-repo', 'master_token', 'http://packagecloud.io', "", nil).and_return('read-token')
+    end
+  end
+
+  context 'no proxy https' do
+    it do
+      response = Net::HTTPSuccess.new(1.0, '200', 'OK')
+      http = instance_double(Net::HTTP) 
+      allow(Net::HTTP).to receive(:new).with('packagecloud.io', 443) { http }
+
+      ssl_store = instance_double(OpenSSL::X509::Store)
+      allow(OpenSSL::X509::Store).to receive(:new) { ssl_store }
+      allow(ssl_store).to receive(:set_default_paths)
+
+      expect(http).to receive(:start) { response }
+      expect(http).to receive(:use_ssl=).with(true)
+      expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+      expect(http).to receive(:cert_store=).with(ssl_store)
+      expect(response).to receive(:body) { 'read-token' }
+
+      is_expected.to run.with_params('test-repo', 'master_token', 'https://packagecloud.io', nil, nil).and_return('read-token')
+    end
+  end
+
+  context 'with proxy http' do
+    it do
+      response = Net::HTTPSuccess.new(1.0, '200', 'OK')
+      http = instance_double(Net::HTTP) 
+      allow(Net::HTTP).to receive(:new).with('packagecloud.io', 80, 'localhost', '8080') { http }
+      expect(http).to receive(:start) { response }
+      expect(response).to receive(:body) { 'read-token' }
+
+      is_expected.to run.with_params('test-repo', 'master_token', 'http://packagecloud.io', 'localhost', '8080').and_return('read-token')
+    end
+  end
+
+  context 'with proxy https' do
+    it do
+      response = Net::HTTPSuccess.new(1.0, '200', 'OK')
+      http = instance_double(Net::HTTP) 
+      allow(Net::HTTP).to receive(:new).with('packagecloud.io', 443, 'localhost', '8080') { http }
+
+      ssl_store = instance_double(OpenSSL::X509::Store)
+      allow(OpenSSL::X509::Store).to receive(:new) { ssl_store }
+      allow(ssl_store).to receive(:set_default_paths)
+
+      expect(http).to receive(:start) { response }
+      expect(http).to receive(:use_ssl=).with(true)
+      expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+      expect(http).to receive(:cert_store=).with(ssl_store)
+      expect(response).to receive(:body) { 'read-token' }
+
+      is_expected.to run.with_params('test-repo', 'master_token', 'https://packagecloud.io', 'localhost', '8080').and_return('read-token')
+    end
+  end
+end


### PR DESCRIPTION
We need to allow using an HTTP proxy to connect to the packagecloud servers to get a packagecloud read token and GPG key (on debian based distros), so that we don't need to require firewalls to be opened up to the packagecloud servers.

This does not configure the package manager to use a proxy. That still needs to be managed separately.